### PR TITLE
Updated CentOS image to Stream, resolving package download issues

### DIFF
--- a/terraform/exec.tf
+++ b/terraform/exec.tf
@@ -13,7 +13,7 @@ resource "null_resource" "copy_cluster_yml" {
     host        = nutanix_virtual_machine.admin_vm.nic_list_status[0].ip_endpoint_list[0].ip
   }
   provisioner "file" {
-    destination = "~/cluster.yml"
+    destination = "/home/nutanix/cluster.yml"
     content = templatefile("${path.module}/templates/cluster.yml.tpl", {
       ssh_username = var.admin_vm_username,
       "rke_worker_nodes" : local.worker_vm_ips,
@@ -45,7 +45,7 @@ resource "null_resource" "configure_admin_vm" {
 
   provisioner "file" {
     content     = file(local_file.rke_private_ssh_key.filename)
-    destination = "~/.ssh/id_rsa"
+    destination = "/home/nutanix/.ssh/id_rsa"
   }
   provisioner "remote-exec" {
     inline = [

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -78,7 +78,7 @@ variable "subnet_name" {
 
 variable "image_url" {
   type        = string
-  default     = "https://cloud.centos.org/centos/8/x86_64/images/CentOS-8-GenericCloud-8.2.2004-20200611.2.x86_64.qcow2"
+  default     = "https://cloud.centos.org/centos/8-stream/x86_64/images/CentOS-Stream-GenericCloud-8-20220125.1.x86_64.qcow2"
   description = "CentOS image URL required to deploy rke"
 }
 


### PR DESCRIPTION
This pull resolves the issue where CentOS is EOL and only Stream is available.   Terraforming fails due to this.   Moving to the Stream image resolves all inconsistencies.   This also includes a fix for ~ not being accepted for paths when creating the yaml files in the /home/nutanix directory.